### PR TITLE
Life, death and respawning

### DIFF
--- a/src/main/java/inf112/skeleton/app/model/GameModel.java
+++ b/src/main/java/inf112/skeleton/app/model/GameModel.java
@@ -78,6 +78,7 @@ public class GameModel {
         //Does the logic, goes through each robot in the list for each phase.
         //gameState is a list off all robot's state, robotState is the specific robot being done a move for.
         for (int i = 0; i < PHASES; i++) {
+            log("CALCULATING PHASE " + i);
             for (Player player : players) {
                 Robot robot = player.getRobot();
                 doCard(i, gameState, gameState.getState(robot), player);
@@ -187,7 +188,7 @@ public class GameModel {
                 tileSteps.get(phaseNumber).add(newState);
                 break;
             case HOLE:
-                newState = initialState.update(robotState.updateDead(true));
+                newState = initialState.update(robotState.updateDead());
                 tileSteps.get(phaseNumber).add(newState);
                 break;
             default:

--- a/src/main/java/inf112/skeleton/app/model/GameModel.java
+++ b/src/main/java/inf112/skeleton/app/model/GameModel.java
@@ -78,7 +78,6 @@ public class GameModel {
         //Does the logic, goes through each robot in the list for each phase.
         //gameState is a list off all robot's state, robotState is the specific robot being done a move for.
         for (int i = 0; i < PHASES; i++) {
-            log("CALCULATING PHASE " + i);
             for (Player player : players) {
                 Robot robot = player.getRobot();
                 doCard(i, gameState, gameState.getState(robot), player);
@@ -92,7 +91,9 @@ public class GameModel {
             gameState = updateLastState(gameState, laserSteps.get(i));
             doFlags(i, gameState);
             gameState = updateLastState(gameState, endOfPhaseSteps.get(i));
+            doBorders(gameState);
         }
+
         // end of turn effects
         doRepairs(gameState);
         doReboot(gameState);
@@ -128,6 +129,17 @@ public class GameModel {
         if (shotsFired) {
             laserSteps.get(phaseNumber).add(laserBeamState);
             laserSteps.get(phaseNumber).add(laserBeamState.clearLaserBeams()); // state without lasers
+        }
+    }
+
+    /**
+     * Edit a game state so that all robots that are outside the board die
+     */
+    private void doBorders(GameState gameState) {
+        for (RobotState state : gameState.getRobotStates()) {
+            if (!state.getDead() && mapHandler.outOfBounds(state.getLocation())) {
+                gameState.edit(state.updateDead());
+            }
         }
     }
 
@@ -319,10 +331,6 @@ public class GameModel {
         if (ENABLE_LOGGING) {
             Gdx.app.log(this.getClass().getName(), message);
         }
-    }
-
-    public int getFinalPhaseSize() {
-        return endOfPhaseSteps.get(4).size();
     }
 
     public Iterable<? extends GameState.LaserBeam> getLaserBeams() {

--- a/src/main/java/inf112/skeleton/app/model/GameState.java
+++ b/src/main/java/inf112/skeleton/app/model/GameState.java
@@ -6,6 +6,7 @@ import inf112.skeleton.app.model.board.RVector2;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class GameState {
     private HashMap<Robot, RobotState> robotMap;
@@ -76,5 +77,10 @@ public class GameState {
             this.target = targetPosition;
             this.shooterIsRobot = shooterIsRobot;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "\n" + robotMap.values().stream().map(RobotState::toString).collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/inf112/skeleton/app/model/GameState.java
+++ b/src/main/java/inf112/skeleton/app/model/GameState.java
@@ -34,8 +34,6 @@ public class GameState {
         if (shooterLocation.getPosition().getX() != (targetPosition.getX()) &&
                 shooterLocation.getPosition().getY() != (targetPosition.getY())) {
             throw new IllegalArgumentException("Points must align vertically or horizontally");
-        } else if (shooterLocation.getPosition().equals(targetPosition)) {
-            throw new IllegalArgumentException("Points must be apart");
         }
         laserBeams.add(new LaserBeam(shooterLocation, targetPosition, shooterIsRobot));
     }

--- a/src/main/java/inf112/skeleton/app/model/Robot.java
+++ b/src/main/java/inf112/skeleton/app/model/Robot.java
@@ -7,11 +7,9 @@ import inf112.skeleton.app.model.board.Location;
 public class Robot {
     private String name = "Anonymous";
     private RobotState state;
-    private int robotLife;
     public Robot(Location location) {
-        this.state = new RobotState(this, location, getMaxHP(), false,
+        this.state = new RobotState(this, location, getMaxHP(), 3,
                 0, location);
-        this.robotLife = 3;
     }
 
     public Robot() {
@@ -41,12 +39,6 @@ public class Robot {
     public RobotState getState() {
         return state.copy();
     }
-
-    public boolean alive() {
-        return !state.getDead();
-    }
-
-    public int getRobotLife(){return robotLife;}
 
     public static int getMaxHP() {
         return 9;

--- a/src/main/java/inf112/skeleton/app/model/Robot.java
+++ b/src/main/java/inf112/skeleton/app/model/Robot.java
@@ -52,4 +52,8 @@ public class Robot {
     public void setName(String name) {
         this.name = name;
     }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/inf112/skeleton/app/model/RobotState.java
+++ b/src/main/java/inf112/skeleton/app/model/RobotState.java
@@ -7,14 +7,14 @@ public class RobotState {
     private Location saveLocation;
     private Location location;
     private int hp;
-    private boolean dead;
     private Robot robot;
+    private int lives;
 
-    public RobotState(Robot robot, Location location, int hp, boolean dead, int capturedFlags, Location saveLocation) {
+    public RobotState(Robot robot, Location location, int hp, int lives, int capturedFlags, Location saveLocation) {
         this.robot = robot;
         this.location = location;
         this.hp = hp;
-        this.dead = dead;
+        this.lives = lives;
         this.saveLocation = saveLocation;
         this.capturedFlags = capturedFlags;
     }
@@ -25,22 +25,23 @@ public class RobotState {
         return other;
     }
 
-    public RobotState updateHP(int decrease) {
-        RobotState other = this.copy();
-        other.hp += decrease;
-        if (other.hp <= 0){
-            other.dead = true;
+    public RobotState updateHP(int difference) {
+        if (this.hp + difference <= 0) {
+            return this.updateDead();
         }
+        RobotState other = this.copy();
+        other.hp = Math.min(this.hp + difference, Robot.getMaxHP());
         return other;
     }
 
     public RobotState copy() {
-        return new RobotState(robot, location.copy(), this.hp, this.dead, capturedFlags, saveLocation);
+        return new RobotState(robot, location.copy(), this.hp, this.lives, capturedFlags, saveLocation);
     }
 
-    public RobotState updateDead(boolean dead) {
+    public RobotState updateDead() {
         RobotState other = this.copy();
-        other.dead = dead;
+        other.hp = 0;
+        other.lives = Math.max(other.lives - 1, 0);
         return other;
     }
 
@@ -65,7 +66,7 @@ public class RobotState {
     }
 
     public boolean getDead() {
-        return dead;
+        return hp <= 0;
     }
 
     public RobotState visitFlag() {
@@ -81,7 +82,6 @@ public class RobotState {
      */
     public RobotState reboot() {
         RobotState other = this.copy();
-        other.dead = false;
         other.location = this.saveLocation;
         other.hp = Robot.getMaxHP();
         return other;
@@ -91,5 +91,9 @@ public class RobotState {
         RobotState other = this.copy();
         other.saveLocation = this.location;
         return other;
+    }
+
+    public int getLives() {
+        return this.lives;
     }
 }

--- a/src/main/java/inf112/skeleton/app/model/RobotState.java
+++ b/src/main/java/inf112/skeleton/app/model/RobotState.java
@@ -81,6 +81,7 @@ public class RobotState {
      * captured flags
      */
     public RobotState reboot() {
+        if (this.lives <= 0) return this; // the robot is out of the game
         RobotState other = this.copy();
         other.location = this.saveLocation;
         other.hp = Robot.getMaxHP();

--- a/src/main/java/inf112/skeleton/app/model/RobotState.java
+++ b/src/main/java/inf112/skeleton/app/model/RobotState.java
@@ -80,10 +80,10 @@ public class RobotState {
      * Come alive if dead and move to the most recently captured flag, or to the starting position if there are no
      * captured flags
      */
-    public RobotState reboot() {
+    public RobotState reboot(Location loc) {
         if (this.lives <= 0) return this; // the robot is out of the game
         RobotState other = this.copy();
-        other.location = this.saveLocation;
+        other.location = loc;
         other.hp = Robot.getMaxHP();
         return other;
     }
@@ -96,5 +96,15 @@ public class RobotState {
 
     public int getLives() {
         return this.lives;
+    }
+
+    @Override
+    public String toString() {
+        return "RobotState{" +
+                robot.getName().toUpperCase() +
+                ": location=" + location +
+                ", hp=" + hp +
+                ", lives=" + lives +
+                '}';
     }
 }

--- a/src/main/java/inf112/skeleton/app/model/board/MapHandler.java
+++ b/src/main/java/inf112/skeleton/app/model/board/MapHandler.java
@@ -208,8 +208,12 @@ public class MapHandler {
     }
 
     public boolean outOfBounds(Location loc) {
-        return (loc.getPosition().getX() >= getWidth() || loc.getPosition().getX() < 0
-                || loc.getPosition().getY() >= getHeight() || loc.getPosition().getY() < 0);
+        return outOfBounds(loc.getPosition());
+    }
+
+    public boolean outOfBounds(RVector2 pos) {
+        return (pos.getX() >= getWidth() || pos.getX() < 0
+                || pos.getY() >= getHeight() || pos.getY() < 0);
     }
 
     public List<Location> getLasersLocations() {

--- a/src/main/java/inf112/skeleton/app/model/board/MapHandler.java
+++ b/src/main/java/inf112/skeleton/app/model/board/MapHandler.java
@@ -177,22 +177,33 @@ public class MapHandler {
     /**
      * Return the first robot in the line of vision from a location, if there is one. Walls block the line of vision
      *
-     * @param location the point of view
-     * @param state    the game state
+     * @param location  the point of view
+     * @param gameState the game state
      * @return a robot that is in the line of vision or null
      */
-    public RobotState robotInLineOfVision(Location location, GameState state) {
+    public RobotState robotInLineOfVision(Location location, GameState gameState, boolean inclusive) {
+        if (inclusive) {
+            RobotState toShoot = getRobotToShoot(location, gameState);
+            if (toShoot != null) return toShoot;
+        }
         Location currentLoc = location;
         while (!(wallInPath(currentLoc) || outOfBounds(currentLoc.forward()))) {
             // if one of the robots is on the next tile then return it
-            for (RobotState robotState : state.getRobotStates()) {
-                if (!robotState.getDead() && robotState.getLocation().getPosition().equals(currentLoc.forward().getPosition())) {
-                    return robotState;
-                }
-            }
+            Location finalCurrentLoc = currentLoc;
+            RobotState toShoot = getRobotToShoot(finalCurrentLoc.forward(), gameState);
+            if (toShoot != null) return toShoot;
             currentLoc = currentLoc.forward();
         }
         return null;
+    }
+
+    private RobotState getRobotToShoot(Location location, GameState gameState) {
+        return gameState.getRobotStates()
+                .stream()
+                .filter(state -> !state.getDead())
+                .filter(state -> state.getLocation().getPosition().equals(location.getPosition()))
+                .findFirst()
+                .orElse(null);
     }
 
     public TiledMapTileLayer getTileLayer() {

--- a/src/main/java/inf112/skeleton/app/model/board/MapHandler.java
+++ b/src/main/java/inf112/skeleton/app/model/board/MapHandler.java
@@ -208,9 +208,8 @@ public class MapHandler {
     }
 
     public boolean outOfBounds(Location loc) {
-        return (loc.getPosition().getX() > getWidth() || loc.getPosition().getX() < 0
-                || loc.getPosition().getY() > getHeight() || loc.getPosition().getY() < 0);
-
+        return (loc.getPosition().getX() >= getWidth() || loc.getPosition().getX() < 0
+                || loc.getPosition().getY() >= getHeight() || loc.getPosition().getY() < 0);
     }
 
     public List<Location> getLasersLocations() {

--- a/src/main/java/inf112/skeleton/app/model/board/RVector2.java
+++ b/src/main/java/inf112/skeleton/app/model/board/RVector2.java
@@ -63,4 +63,12 @@ public class RVector2 {
     public RVector2 cpy() {
         return new RVector2(this.vector.cpy());
     }
+
+    public int distance(RVector2 other) {
+        return Math.abs(this.getX() - other.getX()) + Math.abs(this.getY() - other.getY());
+    }
+
+    public RVector2 translate(int dx, int dy) {
+        return new RVector2(getX() + dx, getY() + dy);
+    }
 }

--- a/src/main/java/inf112/skeleton/app/screens/GameScreen.java
+++ b/src/main/java/inf112/skeleton/app/screens/GameScreen.java
@@ -84,7 +84,7 @@ public class GameScreen extends ScreenAdapter {
         return String.format("%s: %-8s  %s: %d  %s: %d  %s:  %s%n",
                 "NAME", robot.toString(),
                 "HP", robot.getState().getHp(),
-                "LIVES", robot.getRobotLife(),
+                "LIVES", robot.getState().getLives(),
                 "FLAGS", String.format("%d / %d", robot.getState().getCapturedFlags(),
                         gameModel.getMapHandler().getNumberOfFlags()));
     }

--- a/src/main/java/inf112/skeleton/app/view/BoardRenderer.java
+++ b/src/main/java/inf112/skeleton/app/view/BoardRenderer.java
@@ -7,7 +7,6 @@ import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer.Cell;
 import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
 import com.badlogic.gdx.maps.tiled.tiles.StaticTiledMapTile;
-import inf112.skeleton.app.Constants;
 import inf112.skeleton.app.model.GameModel;
 import inf112.skeleton.app.model.Robot;
 import inf112.skeleton.app.model.board.Direction;
@@ -40,10 +39,8 @@ public class BoardRenderer extends OrthogonalTiledMapRenderer {
         TiledMapTileLayer tileLayer = gameModel.getMapHandler().getTileLayer();
         this.robotLayer = new TiledMapTileLayer(tileLayer.getWidth(), tileLayer.getHeight(),
                 (int) tileLayer.getTileWidth(), (int) tileLayer.getTileHeight());
-        robotLayer.setName(Constants.ROBOT_LAYER);
         this.laserLayer = new TiledMapTileLayer(tileLayer.getWidth(), tileLayer.getHeight(),
                 (int) tileLayer.getTileWidth(), (int) tileLayer.getTileHeight());
-        laserLayer.setName(Constants.LASER_LAYER);
 
         // initialize shifted tiles
         float tileWidth = laserLayer.getTileWidth();

--- a/src/main/java/inf112/skeleton/app/view/BoardRenderer.java
+++ b/src/main/java/inf112/skeleton/app/view/BoardRenderer.java
@@ -70,9 +70,8 @@ public class BoardRenderer extends OrthogonalTiledMapRenderer {
         super.render();  // render all static layers
         this.beginRender();
         this.renderMapLayer(laserLayer);
+        this.renderMapLayer(gameModel.getMapHandler().getWallLayer());  // re-render walls over laser beams
         this.renderMapLayer(robotLayer);
-        // re-render wall layer so that wall layers are on top of beams
-        this.renderMapLayer(gameModel.getMapHandler().getWallLayer());
         this.endRender();
     }
 
@@ -104,7 +103,7 @@ public class BoardRenderer extends OrthogonalTiledMapRenderer {
 
     public void updateRobotLayer() {
         for (Robot robot : gameModel.getRobots()) {
-            if (!robot.alive()) continue;
+            if (robot.getState().getDead()) continue;
             Cell cell = robotsToCellsHashMap.get(robot);
             rotateCellToMatchRobot(robot, cell);
             robotLayer.setCell(robot.getX(), robot.getY(), cell);

--- a/src/test/java/inf112/skeleton/app/model/RobotStateTest.java
+++ b/src/test/java/inf112/skeleton/app/model/RobotStateTest.java
@@ -12,7 +12,7 @@ public class RobotStateTest {
     @Before
     public void beforeEach() {
         Robot robot = new Robot();
-        state = new RobotState(robot, robot.getLocation(), 0, false, 0, robot.getLocation());
+        state = new RobotState(robot, robot.getLocation(), 0, 3, 0, robot.getLocation());
     }
 
     @Test


### PR DESCRIPTION
New features
- Robots lose one out of three lives when they die, and if they lose their last life they do not respawn
- Robots die if they go outside the board

Fixes
- Robot gets shot if it stands on the same tile as a laser pointing in their direction. This did not happen before. (Thanks, @MAP-12 for pointing this out)
- Robots re-appear at the closest available position if their saved position is taken. Before they would reappear on the same tile.